### PR TITLE
Verification: Inclusion of extraneous files in the result list

### DIFF
--- a/FlacHash.Tests/Verification/HashEntryMatching_PositionBased_Tests.cs
+++ b/FlacHash.Tests/Verification/HashEntryMatching_PositionBased_Tests.cs
@@ -42,7 +42,7 @@ namespace Andy.FlacHash.Verification
         }
 
         [TestCaseSource(nameof(GetCases_MoreFilesThanExpected))]
-        public void When_Theres_MoreFiles_Than_Hashes__Must_Must_Return_AllHashes_MatchedWithFilesAtRespectiveIndexes_IgnoringExtraFiles(IList<KeyValuePair<string, string>> inputHashes, IList<FileInfo> inputFiles, IList<KeyValuePair<FileInfo, string>> expected)
+        public void When_Theres_MoreFiles_Than_Hashes__Must_Must_Return_AllHashes_MatchedWithFilesAtRespectiveIndexes_Adding_Extras_AtTheEnd(IList<KeyValuePair<string, string>> inputHashes, IList<FileInfo> inputFiles, IList<KeyValuePair<FileInfo, string>> expected)
         {
             var result = HashEntryMatching.MatchFilesToHashesPositionBased(inputHashes, inputFiles).ToList();
 
@@ -52,10 +52,26 @@ namespace Andy.FlacHash.Verification
                 result.Select(x => x.Key),
                 expected.Select(x => x.Key),
                 "File infos");
+        }
+
+        [TestCaseSource(nameof(GetCases_MoreFilesThanExpected))]
+        public void When_TheresExtraFiles_Must_Return_NullsForHashValue(IList<KeyValuePair<string, string>> inputHashes, IList<FileInfo> inputFiles, IList<KeyValuePair<FileInfo, string>> expected)
+        {
+            var extraFiles = inputFiles.Skip(inputHashes.Count).ToList();
+
+            var result = HashEntryMatching.MatchFilesToHashesPositionBased(inputHashes, inputFiles).ToList();
+
+            Assert.IsNotEmpty(result);
 
             AssertThat.CollectionsMatchExactly(
-                result.Select(x => x.Value),
-                expected.Select(x => x.Value),
+                result.Select(x => x.Key),
+                expected.Select(x => x.Key),
+                "File infos");
+
+            var resultExtraFiles = result.Where(x => extraFiles.Select(f => f.Name).Contains(x.Key.Name));
+            AssertThat.CollectionsMatchExactly(
+                resultExtraFiles.Select(x => x.Value),
+                resultExtraFiles.Select(x => (string)null),
                 "Hash values");
         }
 
@@ -184,7 +200,8 @@ namespace Andy.FlacHash.Verification
                 new KeyValuePair<FileInfo, string>[]
                 {
                     new KeyValuePair<FileInfo, string>(file1, hash1),
-                    new KeyValuePair<FileInfo, string>(file2, hash2)
+                    new KeyValuePair<FileInfo, string>(file2, hash2),
+                    new KeyValuePair<FileInfo, string>(file3, null)
                 });
 
             yield return new TestCaseData(
@@ -208,7 +225,9 @@ namespace Andy.FlacHash.Verification
                 {
                     new KeyValuePair<FileInfo, string>(file1, hash1),
                     new KeyValuePair<FileInfo, string>(file2, hash2),
-                    new KeyValuePair<FileInfo, string>(file3, hash3)
+                    new KeyValuePair<FileInfo, string>(file3, hash3),
+                    new KeyValuePair<FileInfo, string>(file4, null),
+                    new KeyValuePair<FileInfo, string>(file5, null)
                 });
         }
 

--- a/FlacHash/Verification/HashEntryMatching.cs
+++ b/FlacHash/Verification/HashEntryMatching.cs
@@ -33,6 +33,10 @@ namespace Andy.FlacHash.Verification
                         matchingFile ?? new FileInfo(string.Format(MissingFileKey, i + 1)),
                         expected.Value);
             }
+
+            var extraneousFiles = files.Skip(expectedHashes.Count);
+            foreach (var file in extraneousFiles)
+                yield return new KeyValuePair<FileInfo, string>(file, null);
         }
 
         /// <summary>
@@ -46,15 +50,25 @@ namespace Andy.FlacHash.Verification
             IEnumerable<FileInfo> files)
         {
             var fileDictionary = files.ToDictionary(x => x.Name, x => x);
+            var tempMatches = new List<FileInfo>();
 
             for (int i = 0; i < expectedHashes.Count; i++)
             {
                 var expected = expectedHashes[i];
                 var matchingFile = fileDictionary.GetValueOrDefault(expected.Key);
 
+                if (matchingFile != null)
+                    tempMatches.Add(matchingFile);
+
                 yield return new KeyValuePair<FileInfo, string>(
                         matchingFile ?? new FileInfo(expected.Key),
                         expected.Value);
+            }
+
+            var extraneousFiles = files.Except(tempMatches);
+            foreach (var file in extraneousFiles)
+            {
+                yield return new KeyValuePair<FileInfo, string>(file, null);
             }
         }
 

--- a/FlacHash/Verification/HashMatch.cs
+++ b/FlacHash/Verification/HashMatch.cs
@@ -5,6 +5,7 @@
         False = 0,
         True = 1,
         Error = 2,
-        NotFound = 3
+        NotFound = 3,
+        NotExpected = 4
     }
 }

--- a/FlacHasher.Cmd.Tests/Verification_Tests.cs
+++ b/FlacHasher.Cmd.Tests/Verification_Tests.cs
@@ -242,6 +242,7 @@ namespace Andy.FlacHash.Application.Cmd
             public string[] HashfileExtensions { get; set; }
             public string HashfileEntrySeparator { get; set; }
             public string InputDirectory { get; set; }
+            public bool InputIgnoreExtraneous { get; set; }
         }
     }
 }

--- a/FlacHasher.Cmd/Operations/Verification.cs
+++ b/FlacHasher.Cmd/Operations/Verification.cs
@@ -20,6 +20,7 @@ namespace Andy.FlacHash.Application.Cmd
             string[] HashfileExtensions { get; set; }
             string HashfileEntrySeparator { get; set; }
             string InputDirectory { get; set; }
+            bool InputIgnoreExtraneous { get; set; }
         }
 
         /// <summary>
@@ -39,12 +40,12 @@ namespace Andy.FlacHash.Application.Cmd
             var hasher = BuildHasher(audioFileDecoder, hashAlgorithm);
             var verifier = BuildVerifier();
 
-            Verify(hasher, verifier, targetFiles, fileHashMap, cancellation);
+            Verify(hasher, verifier, targetFiles, fileHashMap, parameters, cancellation);
         }
 
-        public static void Verify(IMultiFileHasher hasher, HashVerifier hashVerifier, IList<FileInfo> files, FileHashMap fileHashMap, CancellationToken cancellation)
+        public static void Verify(IMultiFileHasher hasher, HashVerifier hashVerifier, IList<FileInfo> files, FileHashMap fileHashMap, IHashfileParams parameters, CancellationToken cancellation)
         {
-            var results = VerifyHashes(files, fileHashMap, hashVerifier, hasher, cancellation);
+            var results = VerifyHashes(files, fileHashMap, hashVerifier, hasher, parameters, cancellation);
 
             WriteStdErrLine();
             WriteStdErrLine();
@@ -58,7 +59,7 @@ namespace Andy.FlacHash.Application.Cmd
             WriteStdErrLine("======== The End =========");
         }
 
-        private static IList<KeyValuePair<FileInfo, HashMatch>> VerifyHashes(IList<FileInfo> files, FileHashMap expectedHashes, HashVerifier hashVerifier, IMultiFileHasher hasher, CancellationToken cancellation)
+        private static IList<KeyValuePair<FileInfo, HashMatch>> VerifyHashes(IList<FileInfo> files, FileHashMap expectedHashes, HashVerifier hashVerifier, IMultiFileHasher hasher, IHashfileParams parameters, CancellationToken cancellation)
         {
             var filesUnique = files
                 .Distinct(new FileInfoEqualityComprarer())
@@ -93,8 +94,9 @@ namespace Andy.FlacHash.Application.Cmd
                 cancellation.ThrowIfCancellationRequested();
             }
 
-            foreach (var file in extraneousFiles.Select(x => x.Key))
-                results.Add(new KeyValuePair<FileInfo, HashMatch>(file, HashMatch.NotExpected));
+            if (!parameters.InputIgnoreExtraneous)
+                foreach (var file in extraneousFiles.Select(x => x.Key))
+                    results.Add(new KeyValuePair<FileInfo, HashMatch>(file, HashMatch.NotExpected));
 
             return results;
         }

--- a/FlacHasher.Cmd/Parameters/VerificationParameters.cs
+++ b/FlacHasher.Cmd/Parameters/VerificationParameters.cs
@@ -25,5 +25,10 @@ namespace Andy.FlacHash.Application.Cmd
         [CmdLineParameter(CmdlineParameterNames.InputDirectory)]
         [AtLeastOneOf("hashfile")]
         public string InputDirectory { get; set; }
+
+        [CmdLineParameter("--ignore-extra")]
+        [IniEntry(nameof(InputIgnoreExtraneous))]
+        [Optional(defaultValue: false)]
+        public bool InputIgnoreExtraneous { get; set; }
     }
 }

--- a/FlacHasher.Cmd/Program.cs
+++ b/FlacHasher.Cmd/Program.cs
@@ -56,7 +56,6 @@ namespace Andy.FlacHash.Application.Cmd
                 verificationSettings = initialCmdlineParams.IsVerification
                     ? parameterReader.GetParameters<VerificationParameters>(allParams, inLowercase: lowercaseParams)
                     : null;
-
             }
             catch (ParameterMissingException e)
             {

--- a/FlacHasher.Win/UI/FormX.cs
+++ b/FlacHasher.Win/UI/FormX.cs
@@ -95,6 +95,7 @@ namespace Andy.FlacHash.Application.Win.UI
             menu_decoderProfiles.SelectedIndexChanged += decoderProfiles_SelectedIndexChanged;
             menu_hashingAlgorithm.SelectedIndexChanged += hashingProfiles_SelectedIndexChanged;
             list_verification_results.Resize += List_verification_results_Resize;
+            list_hashFiles.DoubleClick += HashfileList_DoubleClick;
 
             // Triggers all kinds of handlers
             List_verification_results_Resize(null, null);
@@ -428,6 +429,20 @@ namespace Andy.FlacHash.Application.Win.UI
             this.list_verification_results.Visible = mode == Mode.Verification;
 
             Set_Go_Button_State();
+        }
+
+        void HashfileList_DoubleClick(object sender, EventArgs e)
+        {
+            var hashFile = (FileInfo)list_hashFiles.SelectedItem;
+            var fileHashMap = hashFileParser.Read(hashFile);
+
+            var filesInCurrentDir = fileHashMap.Hashes
+                .Select(
+                    x => new FileInfo(
+                        Path.Combine(directory.FullName, x.Key)))
+                .ToArray();
+
+            list_files.ReplaceItems(filesInCurrentDir);
         }
 
         private void decoderProfiles_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
When the provided input files (or files in the input dir) are not present in the hashfile, they can be included -- optionally.
Cmd-line: controlled via cmd-line params. Winforms - by default, but to onyl work on what's in the hashfile, the contents can be loaded by double-clicking on it.