### PR TITLE
[Winforms] Settings improvements for Resilience: Section & Decoder validations

### DIFF
--- a/FlacHasher.Win/DecoderProfile.cs
+++ b/FlacHasher.Win/DecoderProfile.cs
@@ -7,7 +7,7 @@ namespace Andy.FlacHash.Application.Win
     public class DecoderProfile
     {
         public string Name { get; set; }
-        public FileInfo Decoder { get; set; }
+        public string Decoder { get; set; }
         public string[] DecoderParameters { get; set; }
         public string[] TargetFileExtensions { get; set; }
     }

--- a/FlacHasher.Win/Program.cs
+++ b/FlacHasher.Win/Program.cs
@@ -59,7 +59,9 @@ namespace Andy.FlacHash.Application.Win
                 var hasherFactory = new HasherFactory(processRunner, fileReadProgressReporter, settings);
                 var hashFormatter = new PlainLowercaseHashFormatter();
 
-                System.Windows.Forms.Application.Run(
+                try
+                {
+                    System.Windows.Forms.Application.Run(
                     new UI.FormX(
                         hasherFactory,
                         new UI.InteractiveTextFileWriter(saveHashesToFileDialog),
@@ -76,6 +78,11 @@ namespace Andy.FlacHash.Application.Win
                         settings,
                         openFileDialog_hashfile,
                         openFileDialog_inputFiles));
+                }
+                catch(Exception e)
+                {
+                    MessageBox.Show($"Things have gone south!\n\n{e.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
             }
         }
 

--- a/FlacHasher.Win/SettingsFile.cs
+++ b/FlacHasher.Win/SettingsFile.cs
@@ -52,7 +52,7 @@ namespace Andy.FlacHash.Application.Win
                         return new DecoderProfile
                         {
                             Name = profileSection.Key.Replace($"{ApplicationSettings.DecoderSectionPrefix}.", "", StringComparison.InvariantCultureIgnoreCase),
-                            Decoder = AudioDecoder.ResolveDecoderOrThrow(profileRaw.Decoder),
+                            Decoder = profileRaw.Decoder,
                             DecoderParameters = profileRaw.DecoderParameters,
                             TargetFileExtensions = profileRaw.TargetFileExtensions
                         };
@@ -67,12 +67,13 @@ namespace Andy.FlacHash.Application.Win
 
         static DecoderProfile GetDefaultFlacProfile(ParameterReader paramReader)
         {
+            // Just to fill it with default values
             var profileRaw = paramReader.GetParameters<DecoderProfileTempDefaultFlac>(new Dictionary<string, string[]>());
 
             return new DecoderProfile
             {
                 Name = "FLAC",
-                Decoder = AudioDecoder.ResolveDecoderOrThrow(profileRaw.Decoder),
+                Decoder = profileRaw.Decoder,
                 DecoderParameters = profileRaw.DecoderParameters,
                 TargetFileExtensions = profileRaw.TargetFileExtensions
             };

--- a/FlacHasher.Win/SettingsFile.cs
+++ b/FlacHasher.Win/SettingsFile.cs
@@ -22,7 +22,7 @@ namespace Andy.FlacHash.Application.Win
                 throw new ConfigurationException("The Configuration file is empty");
 
             var settings = Application.SettingsFile.GetSettingsProfile(wholeSettingsFileDictionary, profileName, caseInsensitive: true);
-            Application.SettingsFile.MergeSectionValuesIn(settings, wholeSettingsFileDictionary, Application.SettingsFile.BuildSectionName(ApplicationSettings.HashingSectionPrefix, ApplicationSettings.DefaultHashingSection));
+            Application.SettingsFile.MergeSectionValuesIn(settings, wholeSettingsFileDictionary, Application.SettingsFile.BuildSectionName(ApplicationSettings.HashingSectionPrefix, ApplicationSettings.DefaultHashingSection), isMandatory: false);
 
             var decoderProfiles = wholeSettingsFileDictionary.Where(x => x.Key.StartsWith("Decoder", StringComparison.InvariantCultureIgnoreCase))
                 .ToDictionary(

--- a/FlacHasher.Win/UI/FormX.Designer.cs
+++ b/FlacHasher.Win/UI/FormX.Designer.cs
@@ -346,6 +346,7 @@
             Margin = new System.Windows.Forms.Padding(6, 5, 6, 5);
             Name = "FormX";
             Text = "FormX";
+            Load += FormX_Load;
             tableLayoutPanel1.ResumeLayout(false);
             group_Left.ResumeLayout(false);
             groupVerification.ResumeLayout(false);

--- a/FlacHasher.Win/UI/FormX.cs
+++ b/FlacHasher.Win/UI/FormX.cs
@@ -118,14 +118,18 @@ namespace Andy.FlacHash.Application.Win.UI
             {
                 RefreshHashingFilelist();
             };
+        }
 
+        private void FormX_Load(object sender, EventArgs e)
+        {
             // Triggers all kinds of handlers
             List_hashing_results_Resize(null, null);
             List_verification_results_Resize(null, null);
             SetMode(Mode.Hashing);
-
-            BuildHasherCached(); // needs mode and decoder+algorithm to be pre-set
             ResetStatusMessages();
+
+            // mode and decoder+algorithm have to be pre-set
+            WithTryCatch(BuildHasherCached);
         }
 
         bool listResults_selectionReversal = false;

--- a/FlacHasher.Win/UI/FormX.cs
+++ b/FlacHasher.Win/UI/FormX.cs
@@ -39,6 +39,7 @@ namespace Andy.FlacHash.Application.Win.UI
 
         private NonBlockingHashComputation hasherService;
         Dictionary<HasherKey, NonBlockingHashComputation> hashers = new Dictionary<HasherKey, NonBlockingHashComputation>();
+        Dictionary<string, FileInfo> DecoderExes = new Dictionary<string, FileInfo>();
 
         private bool finishedWithErrors;
         private bool freshOperation = false;
@@ -49,7 +50,7 @@ namespace Andy.FlacHash.Application.Win.UI
 
         private DecoderProfile DecoderProfile => (DecoderProfile)menu_decoderProfiles.SelectedItem;
         private FileExtensionsOption SelectedFileType => (FileExtensionsOption)menu_fileExtensions.SelectedItem;
-        private Algorithm HashingAlgorithmProfile => (Algorithm)menu_hashingAlgorithm.SelectedItem;
+        private Algorithm SelectedHashingAlgorithmProfile => (Algorithm)menu_hashingAlgorithm.SelectedItem;
 
         public FormX(
             HasherFactory hasherFactory,
@@ -170,7 +171,7 @@ namespace Andy.FlacHash.Application.Win.UI
                 ResetLog("Select a hashfile to verify files");
         }
 
-        private async Task WithTryCatch(Func<Task> function)
+        private async Task WithTryCatch_Operation(Func<Task> function)
         {
             try
             {
@@ -178,7 +179,7 @@ namespace Andy.FlacHash.Application.Win.UI
             }
             catch (Exception ex)
             {
-                ShowFatalError(ex);
+                ShowFatalOperationError(ex);
             }
         }
 
@@ -271,13 +272,13 @@ namespace Andy.FlacHash.Application.Win.UI
         {
             var selectedFiles = GetFilesFromUser(openFileDialog_hashfile);
             if (selectedFiles == null) return;
-            
+
             var hashfile = new FileInfo(selectedFiles.First());
             ChooseHashVerificationFile(hashfile);
         }
         void ChooseHashVerificationFile(FileInfo hashfile)
         {
-            
+
             if (hashfile.Length > hashfileMaxSizeBytes && MessageBox.Show(
                         $"The selected hashfile (\"{hashfile.Name}\") is quite big ({hashfileMaxSizeBytes / 1024} kb), " +
                         $"which means it may contain some more serious (and unusable for this purposes) data. " +
@@ -408,7 +409,9 @@ namespace Andy.FlacHash.Application.Win.UI
 
         private async void Btn_Go_Click(object sender, EventArgs e)
         {
-            await WithTryCatch(Go);
+            if (hasherService == null)
+                BuildHasherOrThrow();
+            await WithTryCatch_Operation(Go);
         }
 
         private async Task Go()
@@ -562,7 +565,7 @@ namespace Andy.FlacHash.Application.Win.UI
             progressReporter.Reset(0);
 
             LogMessage("Failed");
-            ShowFatalError(e);
+            ShowFatalOperationError(e);
         }
 
         private async Task ComputeHashes()
@@ -618,10 +621,16 @@ namespace Andy.FlacHash.Application.Win.UI
                 LogMessage(message);
         }
 
-        void ShowFatalError(Exception e)
+        void ShowFatalOperationError(Exception e)
         {
             LogMessage($"Error processing file(s)", e.Message);
             MessageBox.Show($"Operation failed. See the error log", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+
+        void ShowFatalError(Exception e)
+        {
+            ResetLog(e.Message);
+            MessageBox.Show(e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         private void SetMode(Mode mode)
@@ -657,18 +666,24 @@ namespace Andy.FlacHash.Application.Win.UI
 
         private void decoderProfiles_SelectedIndexChanged(object sender, EventArgs e)
         {
-            BuildHasherCached();
+            WithTryCatch(BuildHasherCached);
         }
 
         private void hashingProfiles_SelectedIndexChanged(object sender, EventArgs e)
         {
-            BuildHasherCached();
+            WithTryCatch(BuildHasherCached);
         }
 
-        private void BuildHasher()
+        private void BuildHasherOrThrow()
         {
+            if (!DecoderExes.ContainsKey(DecoderProfile.Decoder))
+            {
+                FileInfo decoderExe = Audio.AudioDecoder.ResolveDecoderOrThrow(DecoderProfile.Decoder);
+                DecoderExes.Add(DecoderProfile.Decoder, decoderExe);
+            }
+
             this.hasherService = HashComputationServiceFactory.Build(
-                hasherFactory.BuildDecoder(DecoderProfile.Decoder, DecoderProfile.DecoderParameters, HashingAlgorithmProfile),
+                hasherFactory.BuildDecoder(DecoderExes[DecoderProfile.Decoder], DecoderProfile.DecoderParameters, SelectedHashingAlgorithmProfile),
                 this,
                 OnOperationFinished,
                 OnFailure,
@@ -677,14 +692,14 @@ namespace Andy.FlacHash.Application.Win.UI
 
         private void BuildHasherCached()
         {
-            var key = new HasherKey(DecoderProfile.Name, HashingAlgorithmProfile);
+            var key = new HasherKey(DecoderProfile.Name, SelectedHashingAlgorithmProfile);
 
             hashers.TryGetValue(key, out hasherService);
 
             if (hasherService != null)
                 return;
 
-            BuildHasher();
+            BuildHasherOrThrow();
             hashers.Add(key, this.hasherService);
         }
 

--- a/FlacHasher/SettingsFile.cs
+++ b/FlacHasher/SettingsFile.cs
@@ -70,7 +70,7 @@ namespace Andy.FlacHash.Application
             MergeSectionValuesIn(settings, settingsDictionary, BuildSectionName(ApplicationSettings.DecoderSectionPrefix, decoderSectionName), caseInsensitive: true);
 
             var hashingSectionName = ResolveConfigValue(settings, ApplicationSettings.HashingProfileKey, hashingProfileName, ApplicationSettings.DefaultHashingSection, caseInsensitive: true);
-            MergeSectionValuesIn(settings, settingsDictionary, BuildSectionName(ApplicationSettings.HashingSectionPrefix, hashingSectionName), caseInsensitive: true);
+            MergeSectionValuesIn(settings, settingsDictionary, BuildSectionName(ApplicationSettings.HashingSectionPrefix, hashingSectionName), caseInsensitive: true, isMandatory: false);
 
             return settings;
         }
@@ -89,10 +89,14 @@ namespace Andy.FlacHash.Application
                     ?? defaultValue;
         }
 
-        public static void MergeSectionValuesIn(IDictionary<string, string> destination, IDictionary<string, IDictionary<string, string>> wholeSettingsFileDictionary, string targetSectionName, bool caseInsensitive = false)
+        public static void MergeSectionValuesIn(IDictionary<string, string> destination, IDictionary<string, IDictionary<string, string>> wholeSettingsFileDictionary, string targetSectionName, bool caseInsensitive = false, bool isMandatory = true)
         {
             var targetSection = TryGetValue(wholeSettingsFileDictionary, targetSectionName, out bool sectionFound, caseInsensitive);
-            if (!sectionFound) throw new ConfigurationException($"Configuration section not found: {targetSectionName}");
+            if (!sectionFound)
+                if (isMandatory)
+                    throw new ConfigurationException($"Configuration section not found: {targetSectionName}");
+                else
+                    return;
             Merge(destination, targetSection);
         }
 

--- a/FlacHasher/SettingsFile.cs
+++ b/FlacHasher/SettingsFile.cs
@@ -67,7 +67,7 @@ namespace Andy.FlacHash.Application
             var settings = GetSettingsProfile(settingsDictionary, profileName, caseInsensitive: true);
 
             var decoderSectionName = ResolveConfigValue(settings, ApplicationSettings.DecoderProfileKey, decoderProfileName, ApplicationSettings.DefaultDecoderSection, caseInsensitive: true);
-            MergeSectionValuesIn(settings, settingsDictionary, BuildSectionName(ApplicationSettings.DecoderSectionPrefix, decoderSectionName), caseInsensitive: true);
+            MergeSectionValuesIn(settings, settingsDictionary, BuildSectionName(ApplicationSettings.DecoderSectionPrefix, decoderSectionName), caseInsensitive: true, isMandatory: false);
 
             var hashingSectionName = ResolveConfigValue(settings, ApplicationSettings.HashingProfileKey, hashingProfileName, ApplicationSettings.DefaultHashingSection, caseInsensitive: true);
             MergeSectionValuesIn(settings, settingsDictionary, BuildSectionName(ApplicationSettings.HashingSectionPrefix, hashingSectionName), caseInsensitive: true, isMandatory: false);


### PR DESCRIPTION
Parameter validations do what's needed -- there's no need to fail the process if a section is not defined because that doesn't give enough info when an error gets thrown. Plus, this prevents default values from kicking in.

Decoder: when decoder can't be found, the application will show an error and allow continuing using the application, selecting a different decoder.