### PR TITLE
Improvements

### DIFF
--- a/Andy.Cmd.Tests/Parameter/ParameterValueResolver_Tests/TypeSpecific/ArrayOfStringType.cs
+++ b/Andy.Cmd.Tests/Parameter/ParameterValueResolver_Tests/TypeSpecific/ArrayOfStringType.cs
@@ -38,6 +38,24 @@ namespace Andy.Cmd.Parameter.ParameterValueResolver_Tests.TypeSpecific
             Assert.AreEqual(expectedValue, prop.GetValue(result));
         }
 
+        [TestCase(nameof(TestParams.Regular), @"ok\;", new[] { "ok;" })]
+        [TestCase(nameof(TestParams.Regular), @"\;ok", new[] { ";ok" })]
+        [TestCase(nameof(TestParams.Regular), @"0;two\;three;four", new[] { "0", "two;three", "four" })]
+        [TestCase(nameof(TestParams.Regular), @"0;two\;;three;four", new[] { "0", "two;", "three", "four" })]
+        public void When_SplittingAnArrayValue_Must_Omit_Escaped_Semicolon__And_UnescapeIt(string propertyName, string value, string[] expectedValue)
+        {
+            var argvs = new Dictionary<string, string[]>
+            {
+                { "arg", new [] { value } }
+            };
+            var prop = typeof(TestParams).GetProperties().First(x => x.Name == propertyName);
+
+            var result = new TestParams();
+            target.ReadParameter(prop, argvs, result);
+
+            Assert.AreEqual(expectedValue, prop.GetValue(result));
+        }
+
         [TestCase(nameof(TestParams.Regular), new[] { "0", "One", "three" }, new[] { "0", "One", "three" })]
         [TestCase(nameof(TestParams.Regular), new[] { "2" }, new[] { "2" })]
         [TestCase(nameof(TestParams.Regular), new[] { "First", "Se Cond" }, new[] { "First", "Se Cond" })]

--- a/Andy.Cmd/Parameter/ParamUtil.cs
+++ b/Andy.Cmd/Parameter/ParamUtil.cs
@@ -24,7 +24,7 @@ namespace Andy.Cmd.Parameter
                         else
                         {
                             var value = optionalAttr.DefaultValue is string[]? (string[])optionalAttr.DefaultValue
-                                : ((string)optionalAttr.DefaultValue).Split(ParameterValueResolver.ArrayValueSeparator);
+                                : ParameterValueResolverFunctions.SplitArrayValue((string)optionalAttr.DefaultValue);
                             property.SetValue(settings, value);
                         }
                     else

--- a/Andy.Cmd/Parameter/ParameterValueResolver.cs
+++ b/Andy.Cmd/Parameter/ParameterValueResolver.cs
@@ -13,6 +13,7 @@ namespace Andy.Cmd.Parameter
     public class ParameterValueResolver : IParameterValueResolver
     {
         public const char ArrayValueSeparator = ';';
+        public const char ArrayValueSeparatorEscapeCharacter = '\\';
 
         public void ReadParameter<T>(PropertyInfo property, IDictionary<string, string[]> arguments, T paramsInstances, bool inLowercase = false)
         {
@@ -151,7 +152,7 @@ namespace Andy.Cmd.Parameter
                     {
                         var split = optionalAttr.DefaultValue is string[]
                             ? (string[])optionalAttr.DefaultValue
-                            : ((string)optionalAttr.DefaultValue).Split(ArrayValueSeparator);
+                            : ParameterValueResolverFunctions.SplitArrayValue((string)optionalAttr.DefaultValue);
                         ParameterValueResolverFunctions.SetArrayValueTrimmed(paramsInstances, property, paramName, split);
                     }
                     return;
@@ -182,7 +183,7 @@ namespace Andy.Cmd.Parameter
                     }
                     else
                     {
-                        var split = value.Split(ArrayValueSeparator);
+                        var split = ParameterValueResolverFunctions.SplitArrayValue(value);
                         ParameterValueResolverFunctions.SetArrayValueTrimmed(paramsInstances, property, paramName, split);
                     }
                 }

--- a/Andy.Cmd/Parameter/ParameterValueResolverFunctions.cs
+++ b/Andy.Cmd/Parameter/ParameterValueResolverFunctions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 
 namespace Andy.Cmd.Parameter
 {
@@ -29,6 +30,37 @@ namespace Andy.Cmd.Parameter
 
         internal static string[] TrimValues(IEnumerable<string> values) =>
             values.Select(x => x?.Trim()).ToArray();
+
+        /// <summary>
+        /// Splits a string on the array value separator, ignoring escaped separators and unescaping them.
+        /// </summary>
+        internal static string[] SplitArrayValue(string value)
+        {
+            var items = new List<string>();
+            var item = new StringBuilder();
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                var character = value[i];
+                if (character == ParameterValueResolver.ArrayValueSeparatorEscapeCharacter
+                    && i + 1 < value.Length
+                    && value[i + 1] == ParameterValueResolver.ArrayValueSeparator)
+                {
+                    item.Append(ParameterValueResolver.ArrayValueSeparator);
+                    i++;
+                }
+                else if (character == ParameterValueResolver.ArrayValueSeparator)
+                {
+                    items.Add(item.ToString());
+                    item.Clear();
+                }
+                else
+                    item.Append(character);
+            }
+            items.Add(item.ToString());
+
+            return items.ToArray();
+        }
 
         internal static void SetArrayValueTrimmed<TParams>(TParams paramsInstances, PropertyInfo property, string paramName, string[] values)
         {


### PR DESCRIPTION
[Parameters] Array values: the use of the element separator is allowed as a normal value - by escaping.