### PR TITLE
[Tests] Alleviate clashing of cross-platform tests with local ones

### DIFF
--- a/.github/workflows/tests-linux-docker.yml
+++ b/.github/workflows/tests-linux-docker.yml
@@ -11,8 +11,8 @@ permissions:
 
 jobs:
 
-  # This compiles the output on the host - doesn't build an image with compiled outout.
-  # That's because I want to have minimal differences between local and remote build definitions,
+  # This compiles the output on the host - it doesn't build an image with compiled output.
+  # That's because I want to have minimal differences between local and remote build set up,
   # and locally, I want to be able to run these tests without copying source into the image.
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-linux-docker.yml
+++ b/.github/workflows/tests-linux-docker.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
 
 jobs:
+
+  # This compiles the output on the host - doesn't build an image with compiled outout.
+  # That's because I want to have minimal differences between local and remote build definitions,
+  # and locally, I want to be able to run these tests without copying source into the image.
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -20,6 +24,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Pull the image
         run: docker compose --file docker-compose-lnx.yml pull tests
+      
+      # Compiled output goes into a host's directory, so it's accessible in the next step (compose run )
       - name: Build
         run: docker compose --file docker-compose-lnx.yml run --rm tests build ${{ env.SLN_ARGS }}
       - name: Run Tests

--- a/.github/workflows/tests-windows-docker.yml
+++ b/.github/workflows/tests-windows-docker.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # For the reason it compiles the output on the host, not in the image, see the comment in the Linux workflow file
   tests:
     runs-on: windows-2022
     timeout-minutes: 20

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -19,8 +19,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v5
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
-      - run: dotnet build ./FlacHasher.sln --configuration Release
-      - run: dotnet test ./FlacHasher.sln --configuration Release --no-build
+      - name: Build
+        run: dotnet build ./FlacHasher.sln --configuration Release
+      - name: Run Tests
+        run: dotnet test ./FlacHasher.sln --configuration Release --no-build

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+build-output/
 
 # StyleCop
 StyleCopReport.xml

--- a/docker-compose-lnx.yml
+++ b/docker-compose-lnx.yml
@@ -13,6 +13,10 @@ services:
     environment:
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+      # Use a different output folder - so it doesn't clash with the host's builds
+      # Put the build files on the host it gets reused between the `docker-compose run` in Workflow steps
+      UseArtifactsOutput: "true"
+      ArtifactsPath: /src/build-output
     volumes:
       - type: bind
         source: .

--- a/docker-compose-win.yml
+++ b/docker-compose-win.yml
@@ -13,6 +13,10 @@ services:
     environment:
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+      # Use a different output folder - so it doesn't clash with the host's builds
+      # Put the build files on the host it gets reused between the `docker-compose run` in Workflow steps
+      UseArtifactsOutput: "true"
+      ArtifactsPath: "c:\\src\\build-output"
     volumes:
       - type: bind
         source: .

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,6 @@
+## Cross-platform Unit Tests
+- *Tailored for quick re-runs locally*. I need to run them locally without having to copy them into the Docker-container and rebuild that every time the source code changes -- for speed. Therefore:
+    1. source code gets volume-mounted to Docker containers (not baked into images)
+    2. build output within the container is saved to a different directory via [ArtifactsPath](./docker-compose-lnx.yml#L19) -- to avoid the output from a container clashing with the output from a local build.
+
+- *CI Test workflows need build output to carry over from one step to the other*. Since source code is built at container run-time (not the image build-time), and it's more straight-forward to start a new container at each step, the output must be saved outside the container (on the host). Therefore, [ArtifactsPath](./docker-compose-lnx.yml#L19) points to a path on the host.


### PR DESCRIPTION
Cross-platform tests, when run in Docker locally can clash with those that are on my host -- because they both end up using the same bin directories. Hence ArtifactsPath - for writing the output, when built in Docker, to a different directory.
They have to get written to a path on the host because that (building at container runtime, not build time) is the only way to build without *copying* source code into the image... and I don't want to keep copying the source into the image because I want to be able to rerun tests quickly.